### PR TITLE
Add the setup and clean script without KServe.

### DIFF
--- a/cleanup-without-kserve.sh
+++ b/cleanup-without-kserve.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e  # 에러 발생 시 종료
+set -o pipefail
+
+echo "🧹 클러스터에서 모든 구성요소 삭제를 시작합니다..."
+
+### 1. 애플리케이션 리소스 삭제
+echo "[1] 애플리케이션 리소스 삭제 중..."
+kubectl delete -f ksvc-ms-frontend.yaml --ignore-not-found
+kubectl delete -f ksvc-ms-backend.yaml --ignore-not-found
+kubectl delete -f postgres.yaml --ignore-not-found
+echo "[1] 애플리케이션 리소스 삭제 완료."
+
+### 2. 모니터링 게이트웨이 삭제
+echo "[2] 모니터링 게이트웨이 삭제 중..."
+kubectl delete -f kiali-gateway.yaml --ignore-not-found
+kubectl delete -f prometheus-gateway.yaml --ignore-not-found
+kubectl delete -f grafana-gateway.yaml --ignore-not-found
+kubectl delete -f jaeger-gateway.yaml --ignore-not-found
+echo "[2] 모니터링 게이트웨이 삭제 완료."
+
+### 3. 모니터링 도구 삭제
+echo "[3] 모니터링 도구 삭제 중..."
+kubectl delete -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/kiali.yaml --ignore-not-found
+kubectl delete -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/grafana.yaml --ignore-not-found
+kubectl delete -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/prometheus.yaml --ignore-not-found
+kubectl delete -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/jaeger.yaml --ignore-not-found
+echo "[3] 모니터링 도구 삭제 완료."
+
+### 4. Knative 삭제
+echo "[4] Knative 삭제 중..."
+kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.18.0/net-istio.yaml --ignore-not-found
+kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-core.yaml --ignore-not-found
+kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-crds.yaml --ignore-not-found
+echo "[4] Knative 삭제 완료."
+
+### 5. Istio 삭제
+echo "[5] Istio 삭제 중..."
+helm uninstall ingressgateway -n istio-system || true
+helm uninstall istiod -n istio-system || true
+helm uninstall istio-base -n istio-system || true
+echo "[5] Istio 삭제 완료."
+
+### 6. 라벨 제거
+echo "[6] 네임스페이스 라벨 제거 중..."
+kubectl label namespace default istio-injection- || true
+kubectl label namespace ms-frontend istio-injection- || true
+kubectl label namespace ms-backend istio-injection- || true
+echo "[6] 네임스페이스 라벨 제거 완료."
+
+### 7. 네임스페이스 삭제
+echo "[7] 네임스페이스 삭제 중..."
+kubectl delete namespace ms-frontend --ignore-not-found --wait=false || true
+kubectl delete namespace ms-backend --ignore-not-found --wait=false || true
+kubectl delete namespace monitoring --ignore-not-found --wait=false || true
+kubectl delete namespace knative-serving --ignore-not-found --wait=false || true
+kubectl delete namespace knative-eventing --ignore-not-found --wait=false || true
+kubectl delete namespace istio-system --ignore-not-found --wait=false || true
+echo "[7] 네임스페이스 삭제 완료."
+
+echo "✅ 모든 구성요소 삭제 완료!" 

--- a/grafana-gateway.yaml
+++ b/grafana-gateway.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: kiali-gateway
+  name: grafana-gateway
   namespace: istio-system
 spec:
   selector:
@@ -12,22 +12,22 @@ spec:
         name: http
         protocol: HTTP
       hosts:
-        - "kiali.monitoring.com" # 여기 원하는 도메인으로 설정
+        - "grafana.monitoring.com"
 
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: kiali-vs
+  name: grafana-vs
   namespace: istio-system
 spec:
   hosts:
-    - "kiali.monitoring.com"
+    - "grafana.monitoring.com"
   gateways:
-    - istio-system/kiali-gateway
+    - istio-system/grafana-gateway
   http:
     - route:
         - destination:
-            host: kiali.istio-system.svc.cluster.local
+            host: grafana.istio-system.svc.cluster.local
             port:
-              number: 20001
+              number: 3000

--- a/jaeger-gateway.yaml
+++ b/jaeger-gateway.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: kiali-gateway
+  name: jaeger-gateway
   namespace: istio-system
 spec:
   selector:
@@ -12,22 +12,22 @@ spec:
         name: http
         protocol: HTTP
       hosts:
-        - "kiali.monitoring.com" # 여기 원하는 도메인으로 설정
+        - "jaeger.monitoring.com" # 원하는 도메인으로 설정
 
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: kiali-vs
+  name: jaeger-vs
   namespace: istio-system
 spec:
   hosts:
-    - "kiali.monitoring.com"
+    - "jaeger.monitoring.com"
   gateways:
-    - istio-system/kiali-gateway
+    - istio-system/jaeger-gateway
   http:
     - route:
         - destination:
-            host: kiali.istio-system.svc.cluster.local
+            host: tracing.istio-system.svc.cluster.local
             port:
-              number: 20001
+              number: 80

--- a/prometheus-gateway.yaml
+++ b/prometheus-gateway.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: kiali-gateway
+  name: prometheus-gateway
   namespace: istio-system
 spec:
   selector:
@@ -12,22 +12,22 @@ spec:
         name: http
         protocol: HTTP
       hosts:
-        - "kiali.monitoring.com" # 여기 원하는 도메인으로 설정
+        - "prometheus.monitoring.com" # 원하는 도메인으로 설정
 
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: kiali-vs
+  name: prometheus-vs
   namespace: istio-system
 spec:
   hosts:
-    - "kiali.monitoring.com"
+    - "prometheus.monitoring.com"
   gateways:
-    - istio-system/kiali-gateway
+    - istio-system/prometheus-gateway
   http:
     - route:
         - destination:
-            host: kiali.istio-system.svc.cluster.local
+            host: prometheus.istio-system.svc.cluster.local
             port:
-              number: 20001
+              number: 9090

--- a/setup-without-kserve.sh
+++ b/setup-without-kserve.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -e  # 에러 발생 시 종료
+set -o pipefail
+
+echo "🚀 KServe를 제외한 구성 요소 설치 시작..."
+
+### 1. 네임스페이스 생성
+echo "[1] 네임스페이스 생성 중..."
+# KServe 관련 네임스페이스 제외
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-eventing
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-frontend
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-backend
+EOF
+echo "[1] 네임스페이스 생성 완료."
+
+### 2. Istio 설치
+echo "[2] Istio 설치 중..."
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+# 이미 설치되어 있는지 확인 후 설치
+if ! helm list -n istio-system | grep -q "istio-base"; then
+  helm install istio-base istio/base -n istio-system
+else
+  echo "istio-base가 이미 설치되어 있어 건너뜁니다."
+fi
+
+if ! helm list -n istio-system | grep -q "istiod"; then
+  helm install istiod istio/istiod -n istio-system --wait
+else
+  echo "istiod가 이미 설치되어 있어 건너뜁니다."
+fi
+
+if ! helm list -n istio-system | grep -q "ingressgateway"; then
+  helm install ingressgateway istio/gateway -n istio-system
+else
+  echo "ingressgateway가 이미 설치되어 있어 건너뜁니다."
+fi
+echo "[2] Istio 설치 완료."
+helm ls -n istio-system 
+
+### 2-1. 라벨 추가 (Istio 설치 이후)
+echo "[2-1] Istio sidecar injection 활성화 중..."
+kubectl label namespace default istio-injection=enabled --overwrite
+kubectl label namespace ms-frontend istio-injection=enabled --overwrite
+kubectl label namespace ms-backend istio-injection=enabled --overwrite
+echo "[2-1] 라벨 추가 완료."
+
+### 3. Knative 설치
+echo "[3] Knative Serving 설치 중..."
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-crds.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-core.yaml
+kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.18.0/net-istio.yaml
+kubectl patch configmap config-domain \
+  -n knative-serving \
+  --type merge \
+  -p '{"data":{"example.com":""}}'
+echo "[3] Knative 설치 완료."
+
+### 4. 모니터링 구성
+echo "[4] 모니터링 서비스 설치 중..."
+# Jaeger
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/jaeger.yaml
+
+# Prometheus
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/prometheus.yaml
+
+# Grafana
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/grafana.yaml
+
+# Kiali
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/kiali.yaml
+
+# 모니터링 도구 Gateway 설정
+echo "[4-1] 모니터링 서비스 게이트웨이 설정 중..."
+kubectl apply -f kiali-gateway.yaml
+kubectl apply -f prometheus-gateway.yaml
+kubectl apply -f grafana-gateway.yaml
+kubectl apply -f jaeger-gateway.yaml
+echo "[4-1] 모니터링 서비스 게이트웨이 설정 완료."
+
+echo "[4] 모니터링 서비스 설치 완료."
+
+### 5. 프론트엔드/백엔드/DB 배포
+echo "[5] 애플리케이션 배포 중..."
+kubectl apply -f postgres.yaml
+kubectl apply -f ksvc-ms-backend.yaml
+kubectl apply -f ksvc-ms-frontend.yaml
+echo "[5] 애플리케이션 배포 완료."
+
+### 6. 정보 출력
+echo "📡 IngressGateway external IP:"
+kubectl get svc ingressgateway -n istio-system
+
+echo "📘 참고: /etc/hosts 에 다음과 같이 도메인 매핑이 필요할 수 있습니다."
+echo "예: 34.XX.XX.XX ms-frontend.ms-frontend.example.com"
+echo "예: 34.XX.XX.XX ms-backend.ms-backend.example.com"
+echo "예: 34.XX.XX.XX kiali.monitoring.com"
+echo "예: 34.XX.XX.XX prometheus.monitoring.com"
+echo "예: 34.XX.XX.XX grafana.monitoring.com"
+echo "예: 34.XX.XX.XX jaeger.monitoring.com"
+
+echo "✅ KServe를 제외한 모든 구성 요소 설치 완료!" 


### PR DESCRIPTION
우선 KServe를 제외한 모든 컴포넌트를 배포할 수 있는 스크립트를 작성하였습니다.

KServe는 추후 업데이트 하도록 하겠습니다.

grafana, prometheus, jaeger의 gateway.yaml을 추가하여 각각의 페이지에 접근할 수 있도록 했습니다.

따라서
[External IP] kiali.monitoring.com
[External IP] prometheus.monitoring.com
[External IP] grafana.monitoring.com
[External IP] jaeger.monitoring.com
[External IP] ms-frontend.ms-frontend.example.com
[External IP] ms-backend.ms-backend.example.com

를 /etc/hosts에 추가하면 접근이 가능합니다.