### PR TITLE
feat: add local minikube Istio gateway setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | `setup-all.sh`          | 전체 클러스터 구성 자동화 스크립트                  |
 | `postgres.yaml`         | PostgreSQL 데이터베이스 배포 구성              |
 | `ksvc-ms-backend.yaml`  | Knative 기반 백엔드 서비스 정의                |
-| `ksvc-ms-frontend.yaml` | Knative 기반 프론트엔드 서비스 정의              |
+| `ksvc-ms-frontend.yaml` | 레거시 프론트엔드 Knative 배포 예시. 기본 구조에서는 프론트엔드를 클러스터 바깥에 배포 |
 | `kiali-gateway.yaml`    | Kiali UI를 외부에 노출시키는 Istio Gateway 설정 |
 | `README.md`             | 프로젝트 설명 문서                           |
 
@@ -37,13 +37,15 @@ chmod +x setup-all.sh
 - host 파일에 도메인 추가
 ```
 [External IP]  kiali.monitoring.com
-[External IP]  ms-frontend.ms-frontend.example.com
+[External IP]  api.example.com
 [External IP]  ms-backend.ms-backend.example.com
 ```
 
 ## 결과물 예시
 
-프론트엔드 접근: http://ms-frontend.ms-frontend.example.com
+API 접근: http://api.example.com
+
+프론트엔드는 Kubernetes 클러스터 바깥(Vercel, S3 + CloudFront, 별도 Nginx 등)에 배포하고 `NEXT_PUBLIC_API_URL`을 Istio Ingress Gateway의 API 도메인으로 설정합니다.
 
 백엔드 접근: http://ms-backend.ms-backend.example.com
 

--- a/apps/api-gateway-knative.yaml
+++ b/apps/api-gateway-knative.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-gateway
+  labels:
+    istio-injection: enabled
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+        autoscaling.knative.dev/target: "50"
+    spec:
+      containers:
+        - image: xxhyeok/ms-api-gateway:latest
+          ports:
+            - containerPort: 8088
+          env:
+            - name: BACKEND_URL
+              value: http://ms-backend.ms-backend.svc.cluster.local
+            - name: ALLOWED_ORIGINS
+              value: http://localhost:3000

--- a/apps/api-gateway.yaml
+++ b/apps/api-gateway.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-gateway
+  labels:
+    istio-injection: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+  labels:
+    app: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: xxhyeok/ms-api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8088
+          env:
+            - name: PORT
+              value: "8088"
+            - name: BACKEND_URL
+              value: http://ms-backend.ms-backend.svc.cluster.local
+            - name: ALLOWED_ORIGINS
+              value: http://localhost:3000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8088
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8088
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - name: http
+      port: 8088
+      targetPort: 8088

--- a/cleanup-all.sh
+++ b/cleanup-all.sh
@@ -7,10 +7,12 @@ echo "🧹 클러스터에서 모든 구성요소 삭제를 시작합니다..."
 
 ### 1. 애플리케이션 리소스 삭제
 echo "[1] 애플리케이션 리소스 삭제 중..."
-kubectl delete -f ksvc-ms-frontend.yaml --ignore-not-found
+kubectl delete -f apps/api-gateway-knative.yaml --ignore-not-found
+kubectl delete -f apps/api-gateway.yaml --ignore-not-found
 kubectl delete -f ksvc-ms-backend.yaml --ignore-not-found
 kubectl delete -f postgres.yaml --ignore-not-found
-kubectl delete -f kserve-sklearn.yaml --ignore-not-found
+kubectl delete -f Kserve-ai-image-serving.yaml --ignore-not-found
+kubectl delete -f Kserve-ai-text-serving.yaml --ignore-not-found
 echo "[1] 애플리케이션 리소스 삭제 완료."
 
 ### 2. Kiali 게이트웨이 삭제
@@ -50,14 +52,14 @@ echo "[6] Istio 삭제 완료."
 ### 7. 라벨 제거
 echo "[7] 네임스페이스 라벨 제거 중..."
 kubectl label namespace default istio-injection- || true
-kubectl label namespace ms-frontend istio-injection- || true
+kubectl label namespace ms-gateway istio-injection- || true
 kubectl label namespace ms-backend istio-injection- || true
 kubectl label namespace ms-models istio-injection- || true
 echo "[7] 네임스페이스 라벨 제거 완료."
 
 ### 8. 네임스페이스 삭제
 echo "[8] 네임스페이스 삭제 중..."
-kubectl delete namespace ms-frontend --ignore-not-found --wait=false || true
+kubectl delete namespace ms-gateway --ignore-not-found --wait=false || true
 kubectl delete namespace ms-backend --ignore-not-found --wait=false || true
 kubectl delete namespace ms-models --ignore-not-found --wait=false || true
 kubectl delete namespace monitoring --ignore-not-found --wait=false || true

--- a/cleanup-without-kserve.sh
+++ b/cleanup-without-kserve.sh
@@ -7,7 +7,8 @@ echo "🧹 Magic DNS 구성을 포함한 구성요소 삭제 (KServe 제외)..."
 
 ### 1. 애플리케이션 리소스 삭제
 echo "[1] 애플리케이션 리소스 삭제 중..."
-kubectl delete -f ksvc-ms-frontend.yaml --ignore-not-found
+kubectl delete -f apps/api-gateway-knative.yaml --ignore-not-found
+kubectl delete -f apps/api-gateway.yaml --ignore-not-found
 kubectl delete -f ksvc-ms-backend.yaml --ignore-not-found
 kubectl delete -f postgres.yaml --ignore-not-found
 echo "[1] 애플리케이션 리소스 삭제 완료."
@@ -50,13 +51,13 @@ echo "[5] Istio 삭제 완료."
 ### 6. 라벨 제거
 echo "[6] 네임스페이스 라벨 제거 중..."
 kubectl label namespace default istio-injection- || true
-kubectl label namespace ms-frontend istio-injection- || true
+kubectl label namespace ms-gateway istio-injection- || true
 kubectl label namespace ms-backend istio-injection- || true
 echo "[6] 네임스페이스 라벨 제거 완료."
 
 ### 7. 네임스페이스 삭제
 echo "[7] 네임스페이스 삭제 중..."
-kubectl delete namespace ms-frontend --ignore-not-found --wait=false || true
+kubectl delete namespace ms-gateway --ignore-not-found --wait=false || true
 kubectl delete namespace ms-backend --ignore-not-found --wait=false || true
 kubectl delete namespace monitoring --ignore-not-found --wait=false || true
 kubectl delete namespace knative-serving --ignore-not-found --wait=false || true

--- a/istio/gateway/api-gateway.yaml
+++ b/istio/gateway/api-gateway.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: ms-serving-gateway
+  namespace: ms-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - ms-serving-gateway
+  http:
+    - name: api
+      match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: api-gateway.ms-gateway.svc.cluster.local
+            port:
+              number: 80
+          headers:
+            request:
+              set:
+                Host: api-gateway.ms-gateway.svc.cluster.local
+      timeout: 30s

--- a/istio/rate-limit/local-rate-limit-api-gateway.yaml
+++ b/istio/rate-limit/local-rate-limit-api-gateway.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: api-gateway-local-rate-limit
+  namespace: ms-gateway
+spec:
+  workloadSelector:
+    labels:
+      app: api-gateway
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: api_gateway_local_rate_limiter
+              token_bucket:
+                max_tokens: 120
+                tokens_per_fill: 120
+                fill_interval: 60s
+              filter_enabled:
+                runtime_key: local_rate_limit_enabled
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              filter_enforced:
+                runtime_key: local_rate_limit_enforced
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              response_headers_to_add:
+                - append: false
+                  header:
+                    key: x-local-rate-limit
+                    value: "true"

--- a/istio/security/authorization-policy.yaml
+++ b/istio/security/authorization-policy.yaml
@@ -1,0 +1,64 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: api-gateway-allow-public-auth
+  namespace: ms-gateway
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  action: ALLOW
+  rules:
+    - to:
+        - operation:
+            methods: ["POST", "OPTIONS"]
+            paths:
+              - /api/auth/login
+              - /api/auth/signup
+    - to:
+        - operation:
+            methods: ["OPTIONS"]
+            paths:
+              - "*"
+    - to:
+        - operation:
+            methods: ["GET"]
+            paths:
+              - /healthz
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: api-gateway-require-jwt
+  namespace: ms-gateway
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            requestPrincipals: ["*"]
+      to:
+        - operation:
+            paths:
+              - /api/user
+              - /api/user/*
+              - /dashboard/*
+              - /user/*
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: backend-only-from-gateway
+  namespace: ms-backend
+spec:
+  selector:
+    matchLabels:
+      serving.knative.dev/service: ms-backend
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces: ["ms-gateway"]

--- a/istio/security/jwt-request-authentication.yaml
+++ b/istio/security/jwt-request-authentication.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: api-gateway-jwt
+  namespace: ms-gateway
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  jwtRules:
+    - issuer: "https://auth.ms-serving.local"
+      jwksUri: "https://auth.ms-serving.local/.well-known/jwks.json"
+      forwardOriginalToken: true
+      fromHeaders:
+        - name: Authorization
+          prefix: "Bearer "

--- a/istio/security/peer-authentication.yaml
+++ b/istio/security/peer-authentication.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default-strict
+  namespace: ms-gateway
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default-strict
+  namespace: ms-backend
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default-strict
+  namespace: ms-models
+spec:
+  mtls:
+    mode: STRICT

--- a/istio/traffic/circuit-breakers.yaml
+++ b/istio/traffic/circuit-breakers.yaml
@@ -1,0 +1,79 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  host: api-gateway.ms-gateway.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 50
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ms-backend
+  namespace: ms-gateway
+spec:
+  host: ms-backend.ms-backend.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 50
+      http:
+        http1MaxPendingRequests: 50
+        maxRequestsPerConnection: 25
+    outlierDetection:
+      consecutive5xxErrors: 3
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ai-image-serving
+  namespace: ms-backend
+spec:
+  host: ai-image-serving-predictor.ms-models.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 20
+      http:
+        http1MaxPendingRequests: 20
+        maxRequestsPerConnection: 10
+    outlierDetection:
+      consecutive5xxErrors: 3
+      interval: 10s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 50
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ai-text-serving
+  namespace: ms-backend
+spec:
+  host: ai-text-serving-predictor.ms-models.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 10
+      http:
+        http1MaxPendingRequests: 10
+        maxRequestsPerConnection: 5
+    outlierDetection:
+      consecutive5xxErrors: 3
+      interval: 10s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 50

--- a/istio/traffic/virtual-services.yaml
+++ b/istio/traffic/virtual-services.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ms-backend-from-gateway
+  namespace: ms-gateway
+spec:
+  hosts:
+    - ms-backend.ms-backend.svc.cluster.local
+  http:
+    - name: auth
+      match:
+        - uri:
+            prefix: /api/auth/
+      route:
+        - destination:
+            host: ms-backend.ms-backend.svc.cluster.local
+      timeout: 5s
+    - name: inference-image
+      match:
+        - uri:
+            exact: /dashboard/image-class
+      route:
+        - destination:
+            host: ms-backend.ms-backend.svc.cluster.local
+      timeout: 10s
+      retries:
+        attempts: 1
+        perTryTimeout: 5s
+        retryOn: connect-failure,refused-stream,5xx
+    - name: inference-text
+      match:
+        - uri:
+            exact: /dashboard/text-summary
+      route:
+        - destination:
+            host: ms-backend.ms-backend.svc.cluster.local
+      timeout: 20s
+      retries:
+        attempts: 1
+        perTryTimeout: 15s
+        retryOn: connect-failure,refused-stream,5xx
+    - name: default
+      route:
+        - destination:
+            host: ms-backend.ms-backend.svc.cluster.local
+      timeout: 10s

--- a/ksvc-ms-backend.yaml
+++ b/ksvc-ms-backend.yaml
@@ -7,10 +7,9 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: "0" # serverless 동작을 위해 0으로 설정
-        autoscaling.knative.dev/maxScale: "5" # 최대 5개 Pod까지 확장 가능
-        # 자동 스케일링 설정
-        autoscaling.knative.dev/target: "50" # 트래픽 부하 기준점 (요청 개수 기준)
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+        autoscaling.knative.dev/target: "50"
     spec:
       initContainers:
         - name: wait-for-database
@@ -26,11 +25,19 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            - name: SPRING_PROFILE
+            - name: SPRING_PROFILES_ACTIVE
               value: prod
-            - name: DATASOURCE_URL
-              value: jdbc:postgresql://database:5432/CC-TERM
-            - name: DATASOURCE_USERNAME
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://database:5432/cc-term
+            - name: SPRING_DATASOURCE_USERNAME
               value: user
-            - name: DATASOURCE_PASSWORD
+            - name: SPRING_DATASOURCE_PASSWORD
               value: "1234"
+            - name: EXTERNAL_AI_IMAGE_URL
+              value: http://ai-image-serving-predictor.ms-models.svc.cluster.local/v1/models/mobilenet:predict
+            - name: EXTERNAL_AI_IMAGE_HOST
+              value: ai-image-serving-predictor.ms-models.svc.cluster.local
+            - name: EXTERNAL_AI_TEXT_URL
+              value: http://ai-text-serving-predictor.ms-models.svc.cluster.local/v1/models/kobart-summary:predict
+            - name: EXTERNAL_AI_TEXT_HOST
+              value: ai-text-serving-predictor.ms-models.svc.cluster.local

--- a/ksvc-ms-frontend.yaml
+++ b/ksvc-ms-frontend.yaml
@@ -1,3 +1,8 @@
+#
+# Legacy optional manifest.
+# The default architecture keeps ms-frontend outside Kubernetes and exposes only
+# the API domain through Istio Ingress Gateway.
+#
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -17,3 +22,5 @@ spec:
           env:
             - name: NODE_ENV
               value: production
+            - name: NEXT_PUBLIC_API_URL
+              value: http://api-gateway.ms-gateway.example.com

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,24 @@
+# Local Runtime
+
+This directory provides a local runtime that avoids requiring Istio, Knative, and KServe during everyday frontend/backend development.
+
+## Run
+
+```bash
+docker compose -f infra/local/docker-compose.yml up --build
+```
+
+## Services
+
+| Service | URL |
+| --- | --- |
+| Frontend | http://localhost:3000 |
+| API Gateway | http://localhost:8088 |
+| Backend | http://localhost:8080 |
+| Image model mock | http://localhost:9001 |
+| Text model mock | http://localhost:9002 |
+| PostgreSQL | localhost:5432 |
+
+## Why Mock Models Exist
+
+The production model path uses KServe. For local development, mock model servers implement the same response shapes expected by `ms-backend`, so UI and backend flows can be developed without a Kubernetes cluster.

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,87 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: cc-term
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: "1234"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d cc-term"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  image-model:
+    build:
+      context: ../../mock-model-server
+    environment:
+      MODEL_KIND: image
+      PORT: 9000
+    ports:
+      - "9001:9000"
+
+  text-model:
+    build:
+      context: ../../mock-model-server
+    environment:
+      MODEL_KIND: text
+      PORT: 9000
+    ports:
+      - "9002:9000"
+
+  backend:
+    build:
+      context: ../../ms-backend
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/cc-term
+      SPRING_DATASOURCE_USERNAME: user
+      SPRING_DATASOURCE_PASSWORD: "1234"
+      APP_JWT_SECRET: local-dev-secret-local-dev-secret-local-dev-secret-local-dev-secret
+      EXTERNAL_AI_IMAGE_URL: http://image-model:9000/v1/models/mobilenet:predict
+      EXTERNAL_AI_IMAGE_HOST: image-model
+      EXTERNAL_AI_TEXT_URL: http://text-model:9000/v1/models/kobart-summary:predict
+      EXTERNAL_AI_TEXT_HOST: text-model
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      image-model:
+        condition: service_started
+      text-model:
+        condition: service_started
+
+  api-gateway:
+    build:
+      context: ../../api-gateway
+    environment:
+      PORT: 8088
+      BACKEND_URL: http://backend:8080
+      ALLOWED_ORIGINS: http://localhost:3000
+    ports:
+      - "8088:8088"
+    depends_on:
+      - backend
+
+  frontend:
+    build:
+      context: ../../ms-frontend
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8088
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: http://localhost:8088
+      NEXT_PUBLIC_GRAFANA_URL: http://localhost:3001
+      NEXT_PUBLIC_KIALI_URL: http://localhost:20001
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api-gateway
+
+volumes:
+  postgres-data:

--- a/local/kind-config.yaml
+++ b/local/kind-config.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 30443
+        hostPort: 8443
+        protocol: TCP

--- a/postgres.yaml
+++ b/postgres.yaml
@@ -20,7 +20,7 @@ spec:
             - containerPort: 5432
           env:
             - name: POSTGRES_DB
-              value: CC-TERM
+              value: cc-term
             - name: POSTGRES_USER
               value: user
             - name: POSTGRES_PASSWORD

--- a/setup-local-minikube.ps1
+++ b/setup-local-minikube.ps1
@@ -1,0 +1,453 @@
+param(
+    [string]$FrontendOrigin = "http://localhost:3000",
+    [string]$DockerRegistry = "xxhyeok",
+    [int]$IngressLocalPort = 8080,
+    [switch]$UseLocalImages = $true,
+    [switch]$SkipMonitoring,
+    [switch]$SkipKServe
+)
+
+$ErrorActionPreference = "Stop"
+
+$InfraDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $InfraDir "..")
+
+$FallbackPathEntries = @(
+    "C:\minikube",
+    "C:\Users\$env:USERNAME\AppData\Local\Microsoft\WinGet\Packages\Helm.Helm_Microsoft.Winget.Source_8wekyb3d8bbwe\windows-amd64"
+)
+
+foreach ($entry in $FallbackPathEntries) {
+    if ((Test-Path $entry) -and (($env:Path -split ";") -notcontains $entry)) {
+        $env:Path = "$entry;$env:Path"
+    }
+}
+
+function Invoke-Step {
+    param(
+        [string]$Message,
+        [scriptblock]$Action
+    )
+
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+    & $Action
+}
+
+function Assert-Command {
+    param([string]$Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "$Name command was not found. Install it, make sure it is on PATH, then run this script again."
+    }
+}
+
+function Apply-Yaml {
+    param([string]$Yaml)
+
+    $tempFile = New-TemporaryFile
+    try {
+        Set-Content -LiteralPath $tempFile -Value $Yaml -Encoding utf8
+        kubectl apply -f $tempFile
+    }
+    finally {
+        Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Wait-For-IngressGatewayService {
+    Write-Host "Waiting for ingressgateway Service..."
+
+    for ($i = 0; $i -lt 30; $i++) {
+        $svc = kubectl get svc ingressgateway -n istio-system --ignore-not-found 2>$null
+        if (-not [string]::IsNullOrWhiteSpace($svc)) {
+            break
+        }
+
+        Write-Host "ingressgateway Service is not ready yet. Retrying in 5 seconds..."
+        Start-Sleep -Seconds 5
+    }
+
+    $svc = kubectl get svc ingressgateway -n istio-system --ignore-not-found 2>$null
+    if ([string]::IsNullOrWhiteSpace($svc)) {
+        throw "ingressgateway Service was not created. Check 'helm list -n istio-system' and Istio gateway installation logs."
+    }
+}
+
+function Start-IngressPortForward {
+    param([int]$LocalPort)
+
+    $existing = Get-CimInstance Win32_Process |
+        Where-Object {
+            $_.CommandLine -match "kubectl" -and
+            $_.CommandLine -match "port-forward" -and
+            $_.CommandLine -match "ingressgateway" -and
+            $_.CommandLine -match "$LocalPort`:80"
+        }
+
+    if ($existing) {
+        Write-Host "IngressGateway port-forward is already running on localhost:$LocalPort"
+        return
+    }
+
+    Write-Host "Starting port-forward watchdog: localhost:$LocalPort -> svc/ingressgateway:80"
+    $loopCmd = "while (`$true) { kubectl port-forward -n istio-system svc/ingressgateway ${LocalPort}:80; Start-Sleep -Seconds 2 }"
+    Start-Process powershell -ArgumentList @("-NoExit", "-Command", $loopCmd) -WindowStyle Minimized
+
+    Start-Sleep -Seconds 3
+}
+
+Assert-Command kubectl
+Assert-Command minikube
+Assert-Command helm
+Assert-Command docker
+
+Invoke-Step "Check minikube and kubectl connectivity" {
+    minikube status
+    kubectl config use-context minikube
+    kubectl get nodes
+}
+
+if ($UseLocalImages) {
+    $BackendImage = "ko.local/ms-backend:local"
+    $GatewayImage = "ko.local/ms-api-gateway:local"
+    $ImagePullPolicy = "IfNotPresent"
+}
+else {
+    $BackendImage = "$DockerRegistry/ms-backend:latest"
+    $GatewayImage = "$DockerRegistry/ms-api-gateway:latest"
+    $ImagePullPolicy = "IfNotPresent"
+}
+
+Invoke-Step "Create namespaces" {
+    Apply-Yaml @"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-backend
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-gateway
+  labels:
+    istio-injection: enabled
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ms-models
+"@
+}
+
+Invoke-Step "Install Istio" {
+    helm repo add istio https://istio-release.storage.googleapis.com/charts
+    helm repo update
+
+    $helmList = helm list -n istio-system
+
+    if ($helmList -notmatch "istio-base") {
+        helm upgrade --install istio-base base --repo https://istio-release.storage.googleapis.com/charts -n istio-system
+    }
+
+    $helmList = helm list -n istio-system
+    if ($helmList -notmatch "istiod") {
+        helm upgrade --install istiod istiod --repo https://istio-release.storage.googleapis.com/charts -n istio-system --wait
+    }
+
+    $helmList = helm list -n istio-system
+    if ($helmList -notmatch "ingressgateway") {
+        helm upgrade --install ingressgateway gateway --repo https://istio-release.storage.googleapis.com/charts -n istio-system
+    }
+
+    kubectl label namespace ms-gateway istio-injection=enabled --overwrite
+    kubectl label namespace ms-backend istio-injection=enabled --overwrite
+    kubectl label namespace ms-models istio-injection=enabled --overwrite
+}
+
+$ApiBaseUrl = "http://localhost:$IngressLocalPort"
+$ParsedApiBaseUrl = [System.Uri]$ApiBaseUrl
+$ApiDomain = $ParsedApiBaseUrl.Host
+$ObservabilityBaseHost = $ParsedApiBaseUrl.Host
+$ObservabilityPort = if ($ParsedApiBaseUrl.IsDefaultPort) { "" } else { ":$($ParsedApiBaseUrl.Port)" }
+
+Write-Host ""
+Write-Host "API base URL: $ApiBaseUrl" -ForegroundColor Green
+Write-Host "Ingress access mode: kubectl port-forward" -ForegroundColor Green
+Write-Host "Allowed external frontend origin: $FrontendOrigin" -ForegroundColor Green
+Write-Host "Use local images: $UseLocalImages" -ForegroundColor Green
+
+Invoke-Step "Install Knative Serving" {
+    kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-crds.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-core.yaml
+    kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.18.0/net-istio.yaml
+
+    kubectl patch configmap config-domain `
+        -n knative-serving `
+        --type merge `
+        -p "{`"data`":{`"example.com`":`"`"}}"
+
+    kubectl patch configmap config-features `
+        -n knative-serving `
+        --type merge `
+        -p "{`"data`":{`"kubernetes.podspec-init-containers`":`"enabled`"}}"
+
+    if ($UseLocalImages) {
+        kubectl patch configmap config-deployment `
+            -n knative-serving `
+            --type merge `
+            -p "{`"data`":{`"registriesSkippingTagResolving`":`"ko.local,dev.local,kind.local,localhost`"}}"
+    }
+}
+
+if (-not $SkipMonitoring) {
+    Invoke-Step "Install observability tools and Gateway routes" {
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/jaeger.yaml
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/prometheus.yaml
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/grafana.yaml
+        kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/kiali.yaml
+
+        Apply-Yaml @"
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: observability-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: observability-vs
+  namespace: istio-system
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - observability-gateway
+  http:
+    - match:
+        - authority:
+            prefix: kiali.
+      route:
+        - destination:
+            host: kiali
+            port:
+              number: 20001
+    - match:
+        - authority:
+            prefix: prometheus.
+      route:
+        - destination:
+            host: prometheus
+            port:
+              number: 9090
+    - match:
+        - authority:
+            prefix: grafana.
+      route:
+        - destination:
+            host: grafana
+            port:
+              number: 3000
+    - match:
+        - authority:
+            prefix: jaeger.
+      route:
+        - destination:
+            host: tracing
+            port:
+              number: 80
+"@
+    }
+}
+
+Invoke-Step "Build local images and load them into minikube" {
+    if ($UseLocalImages) {
+        docker build -t $BackendImage (Join-Path $RepoRoot "ms-backend")
+        docker build -t $GatewayImage (Join-Path $RepoRoot "api-gateway")
+        minikube image load $BackendImage
+        minikube image load $GatewayImage
+    }
+    else {
+        docker build -t $GatewayImage (Join-Path $RepoRoot "api-gateway")
+        docker push $GatewayImage
+    }
+}
+
+Invoke-Step "Deploy PostgreSQL" {
+    kubectl apply -f (Join-Path $InfraDir "postgres.yaml")
+}
+
+Invoke-Step "Deploy backend Knative Service" {
+    Apply-Yaml @"
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: ms-backend
+  namespace: ms-backend
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+        autoscaling.knative.dev/target: "50"
+    spec:
+      initContainers:
+        - name: wait-for-database
+          image: busybox:1.35
+          command:
+            - sh
+            - -c
+            - until nc -z -w 2 database 5432; do echo 'Waiting for database...'; sleep 2; done
+      containers:
+        - image: $BackendImage
+          imagePullPolicy: $ImagePullPolicy
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://database:5432/cc-term
+            - name: SPRING_DATASOURCE_USERNAME
+              value: user
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: "1234"
+            - name: EXTERNAL_AI_IMAGE_URL
+              value: http://ai-image-serving-predictor.ms-models.svc.cluster.local/v1/models/mobilenet:predict
+            - name: EXTERNAL_AI_IMAGE_HOST
+              value: ai-image-serving-predictor.ms-models.svc.cluster.local
+            - name: EXTERNAL_AI_TEXT_URL
+              value: http://ai-text-serving-predictor.ms-models.svc.cluster.local/v1/models/kobart-summary:predict
+            - name: EXTERNAL_AI_TEXT_HOST
+              value: ai-text-serving-predictor.ms-models.svc.cluster.local
+"@
+}
+
+Invoke-Step "Deploy API Gateway Knative Service and Istio Gateway" {
+    Apply-Yaml @"
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+        autoscaling.knative.dev/target: "50"
+    spec:
+      containers:
+        - image: $GatewayImage
+          imagePullPolicy: $ImagePullPolicy
+          ports:
+            - containerPort: 8088
+          env:
+            - name: PORT
+              value: "8088"
+            - name: BACKEND_URL
+              value: http://ms-backend.ms-backend.svc.cluster.local
+            - name: ALLOWED_ORIGINS
+              value: $FrontendOrigin
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: ms-serving-gateway
+  namespace: ms-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - ms-serving-gateway
+  http:
+    - name: api
+      match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: api-gateway.ms-gateway.svc.cluster.local
+            port:
+              number: 80
+          headers:
+            request:
+              set:
+                Host: api-gateway.ms-gateway.svc.cluster.local
+      timeout: 60s
+"@
+}
+
+Invoke-Step "Expose Istio ingressgateway on localhost" {
+    Wait-For-IngressGatewayService
+    Start-IngressPortForward -LocalPort $IngressLocalPort
+}
+
+if (-not $SkipKServe) {
+    Invoke-Step "Install cert-manager and KServe" {
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+
+        kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io
+        kubectl wait --for condition=established --timeout=60s crd/certificaterequests.cert-manager.io
+        kubectl wait --for condition=established --timeout=60s crd/issuers.cert-manager.io
+        kubectl wait --for condition=established --timeout=60s crd/clusterissuers.cert-manager.io
+
+        kubectl wait --for=condition=Ready pod -l app=cert-manager -n cert-manager --timeout=300s
+        kubectl wait --for=condition=Ready pod -l app=cainjector -n cert-manager --timeout=300s
+        kubectl wait --for=condition=Ready pod -l app=webhook -n cert-manager --timeout=300s
+
+        kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.15.0/kserve.yaml
+        kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.15.0/kserve-cluster-resources.yaml
+
+        kubectl apply -f (Join-Path $InfraDir "Kserve-ai-image-serving.yaml")
+        kubectl apply -f (Join-Path $InfraDir "Kserve-ai-text-serving.yaml")
+    }
+}
+
+Write-Host ""
+Write-Host "Setup complete!" -ForegroundColor Green
+Write-Host "API Gateway: $ApiBaseUrl" -ForegroundColor Green
+Write-Host ""
+Write-Host "Put these values into ms-frontend/.env.local, then run npm run dev:"
+Write-Host "NEXT_PUBLIC_API_URL=$ApiBaseUrl"
+Write-Host "NEXT_PUBLIC_GRAFANA_URL=$($ParsedApiBaseUrl.Scheme)://grafana.$ObservabilityBaseHost$ObservabilityPort"
+Write-Host "NEXT_PUBLIC_KIALI_URL=$($ParsedApiBaseUrl.Scheme)://kiali.$ObservabilityBaseHost$ObservabilityPort"

--- a/setup.sh
+++ b/setup.sh
@@ -21,12 +21,14 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ms-frontend
+  name: ms-backend
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ms-backend
+  name: ms-gateway
+  labels:
+    istio-injection: enabled
 ---
 apiVersion: v1
 kind: Namespace
@@ -62,7 +64,7 @@ echo "[2] Istio 설치 완료."
 ### 2-1. 라벨 추가 (Istio 설치 이후)
 echo "[2-1] Istio sidecar injection 활성화 중..."
 kubectl label namespace default istio-injection=enabled --overwrite
-kubectl label namespace ms-frontend istio-injection=enabled --overwrite
+kubectl label namespace ms-gateway istio-injection=enabled --overwrite
 kubectl label namespace ms-backend istio-injection=enabled --overwrite
 kubectl label namespace ms-models istio-injection=enabled --overwrite
 echo "[2-1] 라벨 추가 완료."
@@ -83,7 +85,25 @@ done
 
 # Magic DNS 도메인 설정 (sslip.io 사용)
 MAGIC_DOMAIN="${EXTERNAL_IP}.sslip.io"
+API_DOMAIN="api.${MAGIC_DOMAIN}"
+FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-"http://localhost:3000"}
+USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES:-"false"}
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-"xxhyeok"}
+
+if [[ "${USE_LOCAL_IMAGES}" == "true" ]]; then
+  BACKEND_IMAGE="ko.local/ms-backend:local"
+  GATEWAY_IMAGE="ko.local/ms-api-gateway:local"
+  IMAGE_PULL_POLICY="IfNotPresent"
+else
+  BACKEND_IMAGE="${DOCKER_REGISTRY}/ms-backend:latest"
+  GATEWAY_IMAGE="${DOCKER_REGISTRY}/ms-api-gateway:latest"
+  IMAGE_PULL_POLICY="IfNotPresent"
+fi
+
 echo "Magic DNS 도메인: $MAGIC_DOMAIN"
+echo "API 도메인: $API_DOMAIN"
+echo "허용할 외부 프론트엔드 Origin: $FRONTEND_ORIGIN"
+echo "로컬 이미지 사용: $USE_LOCAL_IMAGES"
 
 ### 4. Knative 설치 및 도메인 설정
 echo "[4] Knative Serving 설치 중..."
@@ -103,6 +123,15 @@ echo "[4] Knative 설치 완료."
 echo "[4-2] Knative initContainers 기능 활성화 중..."
 kubectl patch configmap config-features -n knative-serving --type merge -p '{"data":{"kubernetes.podspec-init-containers":"enabled"}}'
 echo "[4-2] Knative initContainers 기능 활성화 완료."
+
+if [[ "${USE_LOCAL_IMAGES}" == "true" ]]; then
+  echo "[4-3] Knative 로컬 이미지 태그 해석 제외 설정 중..."
+  kubectl patch configmap config-deployment \
+    -n knative-serving \
+    --type merge \
+    -p '{"data":{"registriesSkippingTagResolving":"ko.local,dev.local,kind.local,localhost"}}'
+  echo "[4-3] Knative 로컬 이미지 태그 해석 제외 설정 완료."
+fi
 
 ### 5. 모니터링 구성
 echo "[5] 모니터링 서비스 설치 중..."
@@ -261,9 +290,24 @@ EOF
 echo "[5-1] 모니터링 서비스 게이트웨이 설정 완료."
 echo "[5] 모니터링 서비스 설치 완료."
 
-### 6. 프론트엔드/백엔드/DB 배포
+### 6. API Gateway/백엔드/DB 배포
 echo "[6] 백앤드 및 DB 배포 중..."
 kubectl apply -f postgres.yaml
+
+if [[ "${USE_LOCAL_IMAGES}" == "true" ]]; then
+  echo "[6-local] backend/api-gateway 이미지를 로컬 빌드 후 minikube에 로드합니다..."
+  command -v minikube >/dev/null 2>&1 || {
+    echo "USE_LOCAL_IMAGES=true를 사용하려면 minikube CLI가 필요합니다."
+    exit 1
+  }
+
+  docker build -t ${BACKEND_IMAGE} ../ms-backend
+  docker build -t ${GATEWAY_IMAGE} ../api-gateway
+
+  minikube image load ${BACKEND_IMAGE}
+  minikube image load ${GATEWAY_IMAGE}
+  echo "[6-local] 로컬 이미지 로드 완료: ${BACKEND_IMAGE}, ${GATEWAY_IMAGE}"
+fi
 
 # AI 서비스 URL을 동적으로 설정하여 백엔드 서비스 배포
 echo "[6-0] AI 서비스 URL을 동적으로 설정하여 백엔드 배포..."
@@ -292,51 +336,116 @@ spec:
               "until nc -z -w 2 database 5432; do echo 'Waiting for database...'; sleep 2; done",
             ]
       containers:
-        - image: xxhyeok/ms-backend:latest
+        - image: ${BACKEND_IMAGE}
+          imagePullPolicy: ${IMAGE_PULL_POLICY}
           ports:
             - containerPort: 8080
           env:
-            - name: SPRING_PROFILE
+            - name: SPRING_PROFILES_ACTIVE
               value: prod
-            - name: DATASOURCE_URL
+            - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://database:5432/cc-term
-            - name: DATASOURCE_USERNAME
+            - name: SPRING_DATASOURCE_USERNAME
               value: user
-            - name: DATASOURCE_PASSWORD
+            - name: SPRING_DATASOURCE_PASSWORD
               value: "1234"
+            - name: EXTERNAL_AI_IMAGE_URL
+              value: http://ai-image-serving-predictor.ms-models.svc.cluster.local/v1/models/mobilenet:predict
+            - name: EXTERNAL_AI_IMAGE_HOST
+              value: ai-image-serving-predictor.ms-models.svc.cluster.local
+            - name: EXTERNAL_AI_TEXT_URL
+              value: http://ai-text-serving-predictor.ms-models.svc.cluster.local/v1/models/kobart-summary:predict
+            - name: EXTERNAL_AI_TEXT_HOST
+              value: ai-text-serving-predictor.ms-models.svc.cluster.local
 EOF
 
-### 6-1. 프론트엔드 .env.production 생성
-echo "[6-1] 프론트엔드 .env.production 생성..."
-cat <<EOF > ../ms-frontend/.env.production
-NEXT_PUBLIC_API_URL=http://ms-backend.ms-backend.${MAGIC_DOMAIN}
-NEXT_PUBLIC_GRAFANA_URL=http://grafana.${MAGIC_DOMAIN}
-NEXT_PUBLIC_KIALI_URL=http://kiali.${MAGIC_DOMAIN}
-EOF
+### 6-1. API Gateway 이미지 빌드/푸시 및 배포
+echo "[6-1] API Gateway 이미지 빌드 및 배포..."
 
-### 6-2. Next.js 빌드 및 Docker 이미지 빌드/푸시
-echo "[6-2] Next.js 프론트엔드 빌드 및 이미지 생성..."
-
-DOCKER_REGISTRY=${DOCKER_REGISTRY:-"xxhyeok"}
-FRONTEND_IMAGE="${DOCKER_REGISTRY}/ms-frontend:latest"
-
-cd ../ms-frontend
-npm install
-npm run build
-
-echo "[6-3] Docker 이미지 빌드 및 푸시..."
-docker build --platform linux/amd64 -t ${FRONTEND_IMAGE} .
-docker push ${FRONTEND_IMAGE}; then
-  echo "Docker 이미지 푸시 성공: ${FRONTEND_IMAGE}"
+if [[ "${USE_LOCAL_IMAGES}" != "true" ]]; then
+  cd ../api-gateway
+  docker build --platform linux/amd64 -t ${GATEWAY_IMAGE} .
+  if docker push ${GATEWAY_IMAGE}; then
+    echo "Docker 이미지 푸시 성공: ${GATEWAY_IMAGE}"
+  else
+    echo "Docker 이미지 푸시 실패: ${GATEWAY_IMAGE}"
+    exit 1
+  fi
+  cd ../infra
 else
-  echo "Docker 이미지 푸시 실패: ${FRONTEND_IMAGE}"
-  exit 1
+  echo "[6-1] USE_LOCAL_IMAGES=true 이므로 Docker Hub push를 건너뜁니다."
 fi
-cd ../infra
 
-### 6-4. 프론트엔드 Knative 서비스 배포
-echo "[6-4] Knative 프론트엔드 서비스 배포..."
-kubectl apply -f ksvc-ms-frontend.yaml
+echo "[6-2] API Gateway Knative 서비스 배포..."
+cat <<EOF | kubectl apply -f -
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+        autoscaling.knative.dev/target: "50"
+    spec:
+      containers:
+        - image: ${GATEWAY_IMAGE}
+          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          ports:
+            - containerPort: 8088
+          env:
+            - name: PORT
+              value: "8088"
+            - name: BACKEND_URL
+              value: http://ms-backend.ms-backend.svc.cluster.local
+            - name: ALLOWED_ORIGINS
+              value: ${FRONTEND_ORIGIN}
+EOF
+
+echo "[6-3] API Gateway Istio Gateway/VirtualService 배포..."
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: ms-serving-gateway
+  namespace: ms-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - ${API_DOMAIN}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: api-gateway
+  namespace: ms-gateway
+spec:
+  hosts:
+    - ${API_DOMAIN}
+  gateways:
+    - ms-serving-gateway
+  http:
+    - name: api
+      match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: api-gateway.ms-gateway.svc.cluster.local
+            port:
+              number: 8088
+      timeout: 30s
+EOF
+
 echo "[6] 애플리케이션 배포 완료."
 
 ### 6-5. cert-manager 설치
@@ -390,8 +499,13 @@ echo "  • Prometheus: http://prometheus.${MAGIC_DOMAIN}"
 echo "  • Grafana:    http://grafana.${MAGIC_DOMAIN}"
 echo "  • Jaeger:     http://jaeger.${MAGIC_DOMAIN}"
 echo ""
-echo "  • Frontend:   http://ms-frontend.ms-frontend.${MAGIC_DOMAIN}"
-echo "  • Backend:    http://ms-backend.ms-backend.${MAGIC_DOMAIN}"
+echo "  • API Gateway: http://${API_DOMAIN}"
+echo "  • Backend:     내부 서비스 전용 (ms-backend.ms-backend.svc.cluster.local)"
+echo ""
+echo "🌐 외부 프론트엔드 배포 시 환경변수:"
+echo "  • NEXT_PUBLIC_API_URL=http://${API_DOMAIN}"
+echo "  • FRONTEND_ORIGIN=${FRONTEND_ORIGIN}  # setup.sh 실행 전 실제 프론트엔드 Origin으로 설정"
+echo "  • USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES}  # true이면 Docker Hub push 없이 minikube image load 사용"
 echo ""
 echo "🤖 AI 서비스 URL들:"
 echo "  • AI Image:   http://ai-image-serving.ms-models.${MAGIC_DOMAIN}/v1/models/mobilenet:predict"


### PR DESCRIPTION
## Summary
- Add Istio Gateway, VirtualService, JWT auth, AuthorizationPolicy, circuit breaker, and local rate-limit manifests.
- Add PowerShell-native Minikube setup that builds and loads local images without Docker Hub push.
- Remove frontend from the default in-cluster deployment path and expose API Gateway through Istio ingress.
- Fix local PostgreSQL database name to match backend config.

## Verification
- `./setup-local-minikube.ps1 -SkipKServe -SkipMonitoring`
- `curl http://localhost:8080/healthz` returned HTTP 200